### PR TITLE
Created documentation on the unexpectedChangeSets command (PD-325)

### DIFF
--- a/Content/commands/community/unexpectedChangeSets.html
+++ b/Content/commands/community/unexpectedChangeSets.html
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+    <head>
+        <link href="../../Z_Resources/Stylesheets/TableStyles.css" rel="stylesheet" MadCap:stylesheetType="table" />
+        <meta name="description" content="Reference information and use cases for the XXX command." />
+    </head>
+    <body>
+        <h1><code>unexpectedChangeSets</code> command</h1>
+<p>The <code>unexpectedChangeSets</code> command produces a list of <i><MadCap:variable name="General.Changeset" />s</i > that were run in the database but do not exist in the current <MadCap:variable name="General.changelog" style="font-style: italic;" />.</p>
+<h2>Uses</h2>
+<p>The <code>unexpectedChangeSets</code> command is typically used to detect and compare the changes between the DATABASECHANGELOG table and the current <MadCap:variable name="General.changelog" style="font-style: italic;" />. If any of the <i><MadCap:variable name="General.Changeset" />s</i > in the DATABASECHANGELOG table do not exist in the current <MadCap:variable name="General.changelog" style="font-style: italic;" />, the <code>unexpectedChangeSets</code> command detects those <i><MadCap:variable name="General.Changeset" />s</i > and produces them in your output.</p>
+<p>The <code>unexpectedChangeSets</code> command also produces all the deleted <i><MadCap:variable name="General.Changeset" />s</i > that were previously deployed from the current <MadCap:variable name="General.changelog" style="font-style: italic;" />.</p>
+<p>The image below shows the <MadCap:variable name="General.changelog" style="font-style: italic;" /> that is already applied to the database&mdash;<em>changelog_release1</em>. If you want to apply a new <em>changelog_release2 </em>and it requires information about the previous <i><MadCap:variable name="General.Changeset" />s</i > applied against the database, the <code>unexpectedChangeSets</code> command will list those <i><MadCap:variable name="General.Changeset" />s</i > from <em>changelog_release1</em> and <em>changelog_release2</em>.</p>
+<p>By running the <code>unexpectedChangeSets</code> command, you can review any <i><MadCap:variable name="General.Changeset" />s</i > in the DATABASECHANGELOG table applied from any other <i><MadCap:variable name="General.Changelog" />s</i > outside the scope of your current <MadCap:variable name="General.changelog" style="font-style: italic;" />.</p>
+<h2>Running the <code>unexpectedChangeSets</code> command</h2>
+<p>To run the <code>unexpectedChangeSets</code> command, you need to specify your driver, class path, URL, and user authentication information in your <code>liquibase.properties</code> file. For more information, see <a href="https://docs.liquibase.com/workflows/liquibase-community/creating-config-properties.html?Highlight=liquibase.properties">Creating and configuring a liquibase.properties file</a>. You can also specify these properties in your command line.</p>
+<p>Then run the <code>unexpectedChangeSets</code> command:</p>
+<code>liquibase unexpectedChangeSets</code>
+<p>To see the list of all changes applied, add the --verbose flag while running the command:</p>
+<code>liquibase unexpectedChangeSets --verbose</code>
+<h2> <code>unexpectedChangeSets</code> global attributes</h2>
+<table width="690">
+<tbody>
+<tr>
+<td>
+<p>Attribute</p>
+</td>
+<td>
+<p>Definition</p>
+</td>
+<td>
+<p>Requirement</p>
+</td>
+</tr>
+<tr>
+<td>
+<p>--changeLogFile</p>
+</td>
+<td>
+<p>The root <MadCap:variable name="General.changelog" style="font-style: italic;" /></p>
+</td>
+<td>
+<p><strong>Required</strong></p>
+</td>
+</tr>
+<tr>
+<td>
+<p>--url</p>
+</td>
+<td>
+<p>The JDBC database connection URL</p>
+</td>
+<td>
+<p><strong>Required</strong></p>
+</td>
+</tr>
+<tr>
+<td>
+<p>--username</p>
+</td>
+<td>
+<p>The database username</p>
+</td>
+<td>
+<p><strong>Required</strong></p>
+</td>
+</tr>
+<tr>
+<td>
+<p>--password</p>
+</td>
+<td>
+<p>The database password</p>
+</td>
+<td>
+<p><strong>Required</strong></p>
+</td>
+</tr>
+</tbody>
+</table>
+<MadCap:dropDown>
+    <MadCap:dropDownHead>
+        <MadCap:dropDownHotspot>Output</MadCap:dropDownHotspot>
+    </MadCap:dropDownHead>
+    <MadCap:dropDownBody> 
+        <p>When running the <code>unexpectedChangeSets</code> command with the --verbose flag, the output can be as follows:</p>
+        <pre><code class="language-text">Liquibase Pro 3.9.0 by Datical licensed to Liquibase Pro Customer until Tue Sep 22 19:00:00 CDT 2020
+20 unexpected changes were found in HR_DEV@jdbc:oracle:thin:@support.datical.net:1521:ORCL
+../changelog.oracle.sql::1585673761195-1::support.liquibase.net
+../changelog.oracle.sql::1585673761195-2::support.liquibase.net
+../changelog.oracle.sql::1585673761195-3::support.liquibase.net
+../changelog.oracle.sql::1585673761195-4::support.liquibase.net
+../changelog.oracle.sql::1585673761195-5::support.liquibase.net
+../changelog.oracle.sql::1585673761195-6::support.liquibase.net
+../changelog.oracle.sql::1585673761195-8::support.liquibase.net
+../changelog.oracle.sql::1585673761195-9::support.liquibase.net
+changelog.oracle.sql::158768::SteveZ
+changelog.oracle.sql::1587uye::SteveZ
+changelog.xml::63f54::SteveZ
+changelog.xml::63f434::SteveZ
+changelog.xml::63634::SteveZ
+changelog.oracle.sql::createTable113::Jack
+changelog.oracle.sql::createProc_add_job_history112::Joe
+changelog.oracle.sql::createView_EMP_DETAILS_VIEW112::John
+changeLogWithRunAlways.xml::159120::SteveZ
+samplefile.sql::raw::includeAll
+samplefile.sql::1588246573379-865::rajeshmishra
+samplefile.sql::1::your.name
+Liquibase command 'unexpectedChangeSets' was executed successfully.</code></pre>
+    <p>When running the <code>unexpectedChangeSets</code> command without indicating the --verbose flag, you receive the following output:</p>
+    <pre><code class="language-text">Liquibase Pro 3.9.0 by Datical licensed to Liquibase Pro Customer until Tue Sep 22 19:00:00 CDT 2020
+20 unexpected changes were found in HR_DEV@jdbc:oracle:thin:@support.datical.net:1521:ORCL
+Liquibase command 'unexpectedChangeSets' was executed successfully.        
+    </code></pre>
+</MadCap:dropDownBody>
+</MadCap:dropDown>
+</body>
+</html>

--- a/Content/commands/community/unexpectedChangeSets.html
+++ b/Content/commands/community/unexpectedChangeSets.html
@@ -23,13 +23,13 @@
 <tbody>
 <tr>
 <td>
-<p>Attribute</p>
+<p><strong>Attribute</strong></p>
 </td>
 <td>
-<p>Definition</p>
+<p><strong>Definition</strong></p>
 </td>
 <td>
-<p>Requirement</p>
+<p><strong>Requirement</strong></p>
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
Created new documentation on the unexpectedChangeSets command including the changes proposed. I put the word **list** instead of **number** in the first sentence as it is more precise in this context. I also changed the structure of the sentence you mentioned to the following one: "If you want to apply a new changelog_release2 and it requires information about the previous _changesets_ applied against the database, the unexpectedChangeSets command will list those changesets from changelog_release1 and changelog_release2."
Additionally, I attached the picture that needs to be inserted after the following paragraph "The image below shows..." in the very ticket.
Please review it and let me know whether some other changes are needed.