### PR TITLE
added new mongodb tutorial

### DIFF
--- a/Content/workflows/database-setup-tutorials/mongodb.htm
+++ b/Content/workflows/database-setup-tutorials/mongodb.htm
@@ -1,0 +1,163 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<html xmlns:MadCap="http://www.madcapsoftware.com/Schemas/MadCap.xsd">
+    <head><title>Using Liquibase with MongoDB | Liquibase Docs</title>
+        <link href="../../Z_Resources/Stylesheets/TableStyles.css" rel="stylesheet" MadCap:stylesheetType="table" />
+        <meta name="description" content="This page guides you through the process of creating a new Liquibase project with MongoDB." />
+    </head>
+    <body>
+        <h1>Using <MadCap:variable name="General.Liquibase" /> with MongoDB</h1>
+        <p>The purpose of this document is to guide you through the process of creating a new <MadCap:variable name="General.Liquibase" /> project with MongoDB. In this tutorial, you will generate an example project and follow the instructions to apply and learn concepts associated with creating new <MadCap:variable name="General.Liquibase" /> projects with MongoDB.</p>
+        <h2>Prerequisites</h2>
+        <ul>
+            <li>If you have not installed the latest version of <MadCap:variable name="General.Liquibase" />, navigate to <a href="https://www.liquibase.org/download">https://www.liquibase.org/download</a> to install the Liquibase version 4.0.0.</li>
+            <li>Ensure the <MadCap:variable name="General.Liquibase" /> install directory path is set to a location in the PATH System variable.</li>
+            <li>Navigate to <a href="https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver">https://repo1.maven.org/maven2/org/mongodb/mongo-java-driver</a> and download the jdbc jar file.</li>
+            <li>Navigate to <a href="https://github.com/liquibase/liquibase-mongodb/releases/tag/liquibase-mongodb-4.0.0.2">https://github.com/liquibase/liquibase-mongodb/releases/tag/liquibase-mongodb-4.0.0.2</a> and download the <MadCap:variable name="General.Liquibase" /> extension jar file.</li>
+            <li>Place the two jar files in the <code>liquibase/lib</code> install directory.</li>
+        </ul>
+        <h2>Tutorial</h2>
+        <p>To create a <MadCap:variable name="General.Liquibase" /> project with MongoDB on your machine, begin with the following steps:</p>
+        <ol>
+            <li>Create a new project folder and name it <code>LiquibaseProj</code>.</li>
+            <li>In your <code>LiquibaseProj</code> folder, create a new text file and name it <code>dbchangelog.xml</code>.</li>
+            <li>Open the <code>dbchangelog.xml</code> file and update the <MadCap:variable name="General.changelog" style="font-style: italic;" /> file with the following code snippet:</li>
+        </ol>
+        <figure class="highlight"><pre xml:space="preserve"><code class="language-xml" data-lang="xml">  <span class="cp">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+          <span class="nt">&lt;databaseChangeLog</span>
+            <span class="na">xmlns=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog"</span>
+            <span class="na">xmlns:xsi=</span><span class="s">"http://www.w3.org/2001/XMLSchema-instance"</span>
+            <span class="na">xmlns:ext=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog-ext"</span>
+            <span class="na">xsi:schemaLocation=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+              http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"</span><span class="nt">&gt;</span>
+          <span class="nt">&lt;/databaseChangeLog&gt;</span></code></pre>
+        </figure>
+        <ol MadCap:continue="true">
+            <li>In your <code>LiquibaseProj</code> folder, create a new text file and name it <code>liquibase.properties</code>.</li>
+            <li>Edit the <code>liquibase.properties</code> file to add the following properties:</li><pre><code class="language-html">changeLogFile: dbchangelog.xml
+url: mongodb://hostname:27017/myDatabase
+username: userName
+password: password</code></pre>
+        </ol>
+        <p class="note">If you are unsure about how to configure the url property, more information about the connection string URI format key can be found here <a href="https://docs.mongodb.com/manual/reference/connection-string/">https://docs.mongodb.com/manual/reference/connection-string/</a>.</p>
+        <ol MadCap:continue="true">
+            <li>Add a <MadCap:variable name="General.changeset" style="font-style: italic;" /> to the <MadCap:variable name="General.changelog" style="font-style: italic;" /> – <MadCap:variable name="General.changeset" style="font-style: italic;" /> are uniquely identified by <code>author</code> and <code>id</code> attributes. <MadCap:variable name="General.Liquibase" /> attempts to execute each <MadCap:variable name="General.changeset" style="font-style: italic;" /> in a transaction that is committed at the end.
+In the <code>dbchangelog.xml</code> file add a new collection "myCollection" change set as follows:</li>
+            <figure class="highlight"><pre xml:space="preserve"><code class="language-xml" data-lang="xml">  <span class="cp">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</span>
+  <span class="nt">&lt;databaseChangeLog</span>
+    <span class="na">xmlns=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog"</span>
+    <span class="na">xmlns:xsi=</span><span class="s">"http://www.w3.org/2001/XMLSchema-instance"</span>
+    <span class="na">xmlns:ext=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog-ext"</span>
+    <span class="na">xsi:schemaLocation=</span><span class="s">"http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+      http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"</span><span class="nt">&gt;</span>
+
+      <span class="nt">&lt;changeSet</span>  <span class="na">id=</span><span class="s">"1"</span>  <span class="na">author=</span><span class="s">"bob"</span><span class="nt">&gt;</span>
+          <span class="nt">&lt;ext:createCollection</span>  <span class="na">collectionName=</span><span class="s">"myCollection"</span><span class="nt">&gt;</span>
+              <span class="nt">&lt;ext:options&gt;</span>
+                </code></pre>
+                <p>{</p>
+                <p>validator: {</p>
+                <p>$jsonSchema: {</p>
+                <p>bsonType: "object",</p>
+                <p>required: ["name", "address"],</p>
+                <p>properties: {</p>
+                <p>name: {</p>
+                <p>bsonType: "string",</p>
+                <p>description: "The Name"</p>
+                <p>},</p>
+                <p>address: {</p>
+                <p>bsonType: "string",</p>
+                <p>description: "The Address"</p>
+                <p>}</p>
+                <p>}</p>
+                <p>}</p>
+                <p>},</p>
+                <p>validationAction: "warn",</p>
+                <p>validationLevel: "strict"</p>
+                <p>}</p><pre xml:space="preserve"><code class="language-xml" data-lang="xml">
+              <span class="nt">&lt;/ext:options&gt;</span>
+          <span class="nt">&lt;/ext:createCollection&gt;</span>
+      <span class="nt">&lt;/changeSet&gt;</span>
+  <span class="nt">&lt;/databaseChangeLog&gt;</span></code></pre>
+            </figure>
+            <li>Open the command prompt. Navigate to the LiquibaseProj directory.<br />Run the following command: <code>liquibase update</code></li>
+            <li>From MongoDB Compass Community Tool User Interface, check your database changes under “<strong>myDatabase</strong>”.
+You should see a new “<strong>myCollection</strong>” collection added to the database. For example:</li>
+        </ol><pre xml:space="preserve"><code class="language-sql">use myDatabase</code></pre><pre xml:space="preserve"><code class="language-sql">db.myCollection.find()</code></pre>
+        <table style="margin-left: auto;margin-right: auto;width: 100%;mc-table-style: url('../../Z_Resources/Stylesheets/TableStyles.css');" class="TableStyle-TableStyles" cellspacing="0">
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <thead>
+                <tr class="TableStyle-TableStyles-Head-Header1">
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">ID</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">NAME</th>
+                    <th class="TableStyle-TableStyles-HeadD-Column1-Header1">ACTIVE</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="TableStyle-TableStyles-Body-Body1">
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">NULL</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">NULL</td>
+                    <td class="TableStyle-TableStyles-BodyA-Column1-Body1">NULL</td>
+                </tr>
+            </tbody>
+        </table>
+        <p>Also, you should see two more collections:</p>
+        <ul>
+            <li><strong><MadCap:variable name="General.databasechangelog" /></strong> tracking collection – This collection keeps a record of all the <MadCap:variable name="General.changeset" style="font-style: italic;" /><i>s</i> that were deployed. This way, next time when you deploy again, the <MadCap:variable name="General.changeset" style="font-style: italic;" /><i>s</i> in the <MadCap:variable name="General.changelog" style="font-style: italic;" /> will be compared with the <MadCap:variable name="General.databasechangelog" /> tracking collection and only the new <MadCap:variable name="General.changeset" style="font-style: italic;" /><i>s</i> that were not found in the <MadCap:variable name="General.databasechangelog" /> will be deployed. You will notice that a new data set was created in that table with the <MadCap:variable name="General.changeset" style="font-style: italic;" /> information we have just deployed.
+For this example:</li>
+        </ul>
+        <p><code class="language-sql">db.databaseChangeLog.find()</code>
+        </p>
+        <table style="margin-left: auto;margin-right: auto;width: 100%;mc-table-style: url('../../Z_Resources/Stylesheets/TableStyles.css');" class="TableStyle-TableStyles" cellspacing="0">
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <col class="TableStyle-TableStyles-Column-Column1">
+            </col>
+            <thead>
+                <tr class="TableStyle-TableStyles-Head-Header1">
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">ID</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">AUTHOR</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">FILENAME</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">DATEEXECUTED</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">ORDEREXECUTED</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">EXECTYPE</th>
+                    <th class="TableStyle-TableStyles-HeadE-Column1-Header1">MDSUM</th>
+                    <th class="TableStyle-TableStyles-HeadD-Column1-Header1">…</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr class="TableStyle-TableStyles-Body-Body1">
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">1</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">bob</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">dbchangelog.sql</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1"><code class="highlighter-rouge">date&amp;time</code>
+                    </td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">1</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1">EXECUTED</td>
+                    <td class="TableStyle-TableStyles-BodyB-Column1-Body1"><code class="highlighter-rouge">checksumvalue</code>
+                    </td>
+                    <td class="TableStyle-TableStyles-BodyA-Column1-Body1">…</td>
+                </tr>
+            </tbody>
+        </table>
+        <ul>
+            <li><strong><MadCap:variable name="General.databasechangeloglock" /></strong> – This collection is used internally by <MadCap:variable name="General.Liquibase" /> to manage access to the <MadCap:variable name="General.changelog" style="font-style: italic;" /> collection during deployment.</li>
+        </ul>
+    </body>
+</html>


### PR DESCRIPTION
New MongoDB tutorial created and UTed using the extension v4.0.0.2  https://github.com/liquibase/liquibase-mongodb/releases/tag/liquibase-mongodb-4.0.0.2
And a sample changeLog/changeSet from the following source https://github.com/liquibase/liquibase-mongodb/tree/main/src/test/resources/liquibase/ext