### PR TITLE
Updated Cassandra with the correct working info

### DIFF
--- a/Content/workflows/database-setup-tutorials/cassandra.htm
+++ b/Content/workflows/database-setup-tutorials/cassandra.htm
@@ -11,10 +11,10 @@
         <p>The purpose of this document is to guide you through the process of creating a new <MadCap:variable name="General.Liquibase" /> project with Cassandra. In this tutorial, you will generate an example project and follow the instructions to apply and learn concepts associated with creating new <MadCap:variable name="General.Liquibase" /> projects with Cassandra.</p>
         <h2>Prerequisites</h2>
         <ul>
-            <li>If you have not installed the latest version of <MadCap:variable name="General.Liquibase" />, navigate to <a href="https://www.liquibase.org/download">https://www.liquibase.org/download</a> to install the software application.</li>
+            <li>If you have not installed the latest version of <MadCap:variable name="General.Liquibase" />, navigate to <a href="https://www.liquibase.org/download">https://www.liquibase.org/download</a> to install Liquibase 4.0.0.</li>
             <li>Ensure the <MadCap:variable name="General.Liquibase" /> install directory path is set to a location in the PATH System variable.</li>
-            <li>Navigate to <a href="https://www.simba.com/drivers/cassandra-odbc-jdbc">https://www.simba.com/drivers/cassandra-odbc-jdbc</a> and download the jdbc jar driver file.</li>
-            <li>Navigate to <a href="https://github.com/liquibase/liquibase-Cassandra/releases">https://github.com/liquibase/liquibase-Cassandra/releases</a> and download the latest <MadCap:variable name="General.Liquibase" /> extension jar file.</li>
+            <li>Navigate to <a href="https://downloads.datastax.com/#odbc-jdbc-drivers">https://downloads.datastax.com/#odbc-jdbc-drivers</a> and download the Simba jdbc jar driver file for Apache Cassandra.</li>
+            <li>Navigate to <a href="https://github.com/liquibase/liquibase-cassandra/releases/tag/liquibase-cassandra-4.0.0.2">https://github.com/liquibase/liquibase-cassandra/releases/tag/liquibase-cassandra-4.0.0.2</a> and download the liquibase-cassandra-4.0.0.2.jar <MadCap:variable name="General.Liquibase" /> extension jar file.</li>
             <li>Place the two jar files in the <code>liquibase/lib</code> install directory.</li>
         </ul>
         <h2>Tutorial</h2>


### PR DESCRIPTION
Updated Cassandra with the correct extension and Liquibase versions (4.0.0 and 4.0.0.2) + link to downloads.datastax.com website to download the JDBC driver.