### PR TITLE
Resolve confusion about earlier vs. later

### DIFF
--- a/Content/tools-integrations/maven/using-liquibase-and-maven-pom-file.htm
+++ b/Content/tools-integrations/maven/using-liquibase-and-maven-pom-file.htm
@@ -6,7 +6,7 @@
     </head>
     <body>
         <h1>Using <MadCap:variable name="General.Liquibase" /> and your Maven POM File</h1>
-        <p>It is recommended to use Apache Maven 3.1 or earlier to make it easier to configure the <a href="https://maven.apache.org/maven-logging.html">log-level of <MadCap:variable name="General.Liquibase" /> Maven plugin</a> with MAVEN_OPTs or by passing the following command: <code class="highlighter-rouge">-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG</code>. You can also edit the properties in the <code>${maven.home}/conf/logging/simplelogger.properties</code> file.
+        <p>It is recommended to use Apache Maven 3.1 or later to make it easier to configure the <a href="https://maven.apache.org/maven-logging.html">log-level of <MadCap:variable name="General.Liquibase" /> Maven plugin</a> with MAVEN_OPTs or by passing the following command: <code class="highlighter-rouge">-Dorg.slf4j.simpleLogger.defaultLogLevel=DEBUG</code>. You can also edit the properties in the <code>${maven.home}/conf/logging/simplelogger.properties</code> file.
         </p>
         <h2>Paths to files</h2>
         <p>As of version 1.6.1.0 of the Maven plugin, all files are resolved from the Maven test classpath for the Maven project or an absolute path. This allows for your <MadCap:xref href="../../concepts/basic/changelog.html" style="font-style: italic;font-weight: bold;">[%=General.changelog%]</MadCap:xref> to be present in other Maven artifacts (on the classpath) and to be used to invoke <MadCap:variable name="General.Liquibase" /> on a database.</p>


### PR DESCRIPTION
The original term "earlier" probably was meant to be interpreted as "newer" i.e. a more recent version than 3.1.