### PR TITLE
Fix create procedure yaml re using procedure body not procedure text use procedure body

### DIFF
--- a/Content/change-types/community/create-procedure.html
+++ b/Content/change-types/community/create-procedure.html
@@ -87,156 +87,82 @@ Or You can also specify that a change is <b>NOT</b> applicable to a particular d
                 </tr>
             </tbody>
         </table>
-        <h3>XML example</h3><pre xml:space="preserve">
-            <code class="language-xml" data-lang="xml">
-                <span class="nt">&lt;changeSet</span>  <span class="na">author=</span><span class="s">"liquibase-docs"</span>  <span class="na">id=</span><span class="s">"createProcedure-example"</span><span class="nt">&gt;</span>  
-    <span class="nt">&lt;createProcedure</span>  <span class="na">catalogName=</span><span class="s">"cat"</span>  
-            <span class="na">comments=</span><span class="s">"A String"</span>  
-            <span class="na">dbms=</span><span class="s">"h2, !oracle, mysql"</span>  
-            <span class="na">encoding=</span><span class="s">"UTF-8"</span>  
-            <span class="na">path=</span><span class="s">"com/example/my-logic.sql"</span>  
-            <span class="na">procedureName=</span><span class="s">"new_customer"</span>  
-            <span class="na">relativeToChangelogFile=</span><span class="s">"true"</span>  
-            <span class="na">replaceIfExists=</span><span class="s">"false"</span>  
-            <span class="na">schemaName=</span><span class="s">"public"</span><span class="nt">&gt;</span>CREATE OR REPLACE PROCEDURE testHello
-    IS
-    BEGIN
-      DBMS_OUTPUT.PUT_LINE('Hello From The Database!');
-    END;<span class="nt">&lt;/createProcedure&gt;</span>  
-<span class="nt">&lt;/changeSet&gt;</span></code>
+        <h3>XML example</h3>
+        <pre xml:space="preserve">
+          <code class="language-xml" data-lang="xml">
+<span class="nt">&lt;changeSet</span> <span class="na">author=</span><span class="s">"liquibase-docs"</span> <span class="na">id=</span><span class="s">"createProcedure-example"</span><span class="nt">&gt;</span>
+  <span class="nt">&lt;createProcedure</span> <span class="na">catalogName=</span><span class="s">"cat"</span>
+                   <span class="na">comments=</span><span class="s">"A String"</span>
+                   <span class="na">dbms=</span><span class="s">"h2, !oracle, mysql"</span>
+                   <span class="na">encoding=</span><span class="s">"UTF-8"</span>
+                   <span class="na">path=</span><span class="s">"com/example/my-logic.sql"</span>
+                   <span class="na">procedureName=</span><span class="s">"new_customer"</span>
+                   <span class="na">relativeToChangelogFile=</span><span class="s">"true"</span>
+                   <span class="na">replaceIfExists=</span><span class="s">"false"</span>
+                   <span class="na">schemaName=</span><span class="s">"public"</span><span class="nt">&gt;</span>
+    CREATE OR REPLACE PROCEDURE testHello
+      IS
+      BEGIN
+        DBMS_OUTPUT.PUT_LINE('Hello From The Database!');
+      END;
+  <span class="nt">&lt;/createProcedure&gt;</span>
+<span class="nt">&lt;/changeSet&gt;</span>
+          </code>
         </pre>
-        <h3>YAML example</h3><pre xml:space="preserve">
-            <code class="language-yaml" data-lang="yaml">
-                <span class="na">changeSet</span>
-                <span class="pi">:</span>  
-  <span class="na">id</span><span class="pi">:</span>  <span class="s">createProcedure-example</span>  
-  <span class="na">author</span><span class="pi">:</span>  <span class="s">liquibase-docs</span>  
-  <span class="na">changes</span><span class="pi">:</span>  
-  <span class="pi">-</span>  <span class="na">createProcedure</span><span class="pi">:</span>  
-      <span class="na">catalogName</span><span class="pi">:</span>  <span class="s">cat</span>  
-      <span class="na">comments</span><span class="pi">:</span>  <span class="s">A String</span>  
-      <span class="na">dbms</span><span class="pi">:</span>  <span class="s">h2, !oracle, mysql</span>  
-      <span class="na">encoding</span><span class="pi">:</span>  <span class="s">UTF-8</span>  
-      <span class="na">path</span><span class="pi">:</span>  <span class="s">com/example/my-logic.sql</span>  
-      <span class="na">procedureText</span><span class="pi">:</span>  <span class="pi">|-</span>  
-        <span class="no">CREATE OR REPLACE PROCEDURE testHello</span>  
-            <span class="no">IS</span>  
-            <span class="no">BEGIN</span>  
-              <span class="no">DBMS_OUTPUT.PUT_LINE('Hello From The Database!');</span>  
-            <span class="no">END;</span>  
-      <span class="no">procedureName: new_customer</span>  
-      <span class="no">relativeToChangelogFile: true</span>  
-      <span class="no">replaceIfExists: false</span>  
-      <span class="no">schemaName: public</span></code>
+        <h3>YAML example</h3>
+        <pre xml:space="preserve">
+          <code class="language-yaml" data-lang="yaml">
+<span class="na">changeSet</span><span class="pi">:</span>
+  <span class="na">id</span><span class="pi">:</span>  <span class="s">createProcedure-example</span>
+  <span class="na">author</span><span class="pi">:</span>  <span class="s">liquibase-docs</span>
+  <span class="na">changes</span><span class="pi">:</span>
+  <span class="pi">-</span>  <span class="na">createProcedure</span><span class="pi">:</span>
+      <span class="na">catalogName</span><span class="pi">:</span>  <span class="s">cat</span>
+      <span class="na">comments</span><span class="pi">:</span>  <span class="s">A String</span>
+      <span class="na">dbms</span><span class="pi">:</span>  <span class="s">h2, !oracle, mysql</span>
+      <span class="na">encoding</span><span class="pi">:</span>  <span class="s">UTF-8</span>
+      <span class="na">path</span><span class="pi">:</span>  <span class="s">com/example/my-logic.sql</span>
+      <span class="na">procedureText</span><span class="pi">:</span>  <span class="pi">|-</span>
+        <span class="no">CREATE OR REPLACE PROCEDURE testHello</span>
+            <span class="no">IS</span>
+            <span class="no">BEGIN</span>
+              <span class="no">DBMS_OUTPUT.PUT_LINE('Hello From The Database!');</span>
+            <span class="no">END;</span>
+      <span class="no">procedureName: new_customer</span>
+      <span class="no">relativeToChangelogFile: true</span>
+      <span class="no">replaceIfExists: false</span>
+      <span class="no">schemaName: public</span>
+          </code>
         </pre>
-        <h3>JSON example</h3><pre xml:space="preserve">
-            <code class="language-json" data-lang="json">
-                <span class="p">{</span>
-                <span class="w">  </span>
-                <span class="s2">"changeSet"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="p">{</span>
-                <span class="w">  </span>
-                <span class="s2">"id"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"createProcedure-example"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"author"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"liquibase-docs"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"changes"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="p">[</span>
-                <span class="w">  </span>
-                <span class="p">{</span>
-                <span class="w">  </span>
-                <span class="s2">"createProcedure"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="p">{</span>
-                <span class="w">  </span>
-                <span class="s2">"catalogName"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"cat"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"comments"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"A String"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"dbms"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"h2, !oracle, mysql"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"encoding"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"UTF-8"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"path"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"com/example/my-logic.sql"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"procedureText"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"CREATE OR REPLACE PROCEDURE testHello</span>
-                <span class="se">\n</span>
-                <span class="s2">    IS</span>
-                <span class="se">\n</span>
-                <span class="s2">    BEGIN</span>
-                <span class="se">\n</span>
-                <span class="s2">      DBMS_OUTPUT.PUT_LINE('Hello From The Database!');</span>
-                <span class="se">\n</span>
-                <span class="s2">    END;"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"procedureName"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"new_customer"</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"relativeToChangelogFile"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="kc">true</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"replaceIfExists"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="kc">false</span>
-                <span class="p">,</span>
-                <span class="w">  </span>
-                <span class="s2">"schemaName"</span>
-                <span class="p">:</span>
-                <span class="w">  </span>
-                <span class="s2">"public"</span>
-                <span class="w">  </span>
-                <span class="p">}</span>
-                <span class="w">  </span>
-                <span class="p">}]</span>
-                <span class="w">  </span>
-                <span class="p">}</span>
-                <span class="w">  </span>
-                <span class="p">}</span>
-            </code>
+        <h3>JSON example</h3>
+        <pre xml:space="preserve">
+          <code class="language-json" data-lang="json">
+<span class="p">{</span>
+<span class="w">  </span><span class="s2">"changeSet"</span><span class="p">:</span><span class="w">  </span><span class="p">{</span>
+  <span class="w">  </span><span class="s2">"id"</span><span class="p">:</span><span class="w"> </span><span class="s2">"createProcedure-example"</span><span class="p">,</span>
+  <span class="w">  </span><span class="s2">"author"</span><span class="p">:</span><span class="w"> </span><span class="s2">"liquibase-docs"</span><span class="p">,</span>
+  <span class="w">  </span><span class="s2">"changes"</span><span class="p">:</span><span class="w"> </span><span class="p">[</span><span class="p">{</span>
+  <span class="w">    </span><span class="s2">"createProcedure"</span><span class="p">:</span><span class="w"> </span><span class="p">{</span>
+  <span class="w">      </span><span class="s2">"catalogName"</span><span class="p">:</span><span class="w"> </span><span class="s2">"cat"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"comments"</span><span class="p">:</span><span class="w"> </span><span class="s2">"A String"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"dbms"</span><span class="p">:</span><span class="w"> </span><span class="s2">"h2, !oracle, mysql"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"encoding"</span><span class="p">:</span><span class="w"> </span><span class="s2">"UTF-8"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"path"</span><span class="p">:</span><span class="w"> </span><span class="s2">"com/example/my-logic.sql"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"procedureText"</span><span class="p">:</span>
+  <span class="w">        </span><span class="s2">"CREATE OR REPLACE PROCEDURE testHello</span><span class="se">\n</span>
+  <span class="s2">         IS</span><span class="se">\n</span>
+  <span class="s2">          BEGIN</span><span class="se">\n</span>
+  <span class="s2">            DBMS_OUTPUT.PUT_LINE('Hello From The Database!');</span><span class="se">\n</span>
+  <span class="s2">          END;"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"procedureName"</span><span class="p">:</span><span class="w"> </span><span class="s2">"new_customer"</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"relativeToChangelogFile"</span><span class="p">:</span><span class="w"> </span><span class="kc">true</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"replaceIfExists"</span><span class="p">:</span><span class="w"> </span><span class="kc">false</span><span class="p">,</span>
+  <span class="w">      </span><span class="s2">"schemaName"</span><span class="p">:</span><span class="w"> </span><span class="s2">"public"</span>
+  <span class="w">    </span><span class="p">}</span>
+  <span class="w">  </span><span class="p">}]</span>
+<span class="w">  </span><span class="p">}</span>
+<span class="p">}</span>
+          </code>
         </pre>
         <h2 id="database-support">Database support</h2>
         <table style="border: 1;mc-table-style: url('../../Z_Resources/Stylesheets/TableStyles.css');margin-left: auto;margin-right: auto;" class="TableStyle-TableStyles" cellspacing="0">

--- a/Content/change-types/community/create-procedure.html
+++ b/Content/change-types/community/create-procedure.html
@@ -122,7 +122,7 @@ Or You can also specify that a change is <b>NOT</b> applicable to a particular d
       <span class="na">dbms</span><span class="pi">:</span>  <span class="s">h2, !oracle, mysql</span>
       <span class="na">encoding</span><span class="pi">:</span>  <span class="s">UTF-8</span>
       <span class="na">path</span><span class="pi">:</span>  <span class="s">com/example/my-logic.sql</span>
-      <span class="na">procedureText</span><span class="pi">:</span>  <span class="pi">|-</span>
+      <span class="na">procedureBody</span><span class="pi">:</span>  <span class="pi">|-</span>
         <span class="no">CREATE OR REPLACE PROCEDURE testHello</span>
             <span class="no">IS</span>
             <span class="no">BEGIN</span>
@@ -134,6 +134,7 @@ Or You can also specify that a change is <b>NOT</b> applicable to a particular d
       <span class="no">schemaName: public</span>
           </code>
         </pre>
+        <p>NB: the deprecated attribute <code>procedureBody</code> must be used at this time instead of <code>procedureText</code>.</p>
         <h3>JSON example</h3>
         <pre xml:space="preserve">
           <code class="language-json" data-lang="json">


### PR DESCRIPTION
This pull request primarily updates the documentation for createProcedure.

1. It fixes the sample code for yaml, using procedureBody instead of procedureText, which doesn't work for yaml as per https://liquibase.jira.com/browse/CORE-1847.
2. It fixes the indentation of xml, yaml and json sample code blocks.

I initially raised a [discussion](https://forum.liquibase.org/t/documentation-still-wrong-about-createprocedure-yamls-proceduretext-attribute-how-to-update/5318) to ask why the original issue had been closed as "By design" but thought it'll be more helpful to just update the docs to enable others to find the answer quickly and officially.