### PR TITLE
force is not needed for helper command

### DIFF
--- a/Content/commands/pro/rollbackonechangesetsql.html
+++ b/Content/commands/pro/rollbackonechangesetsql.html
@@ -29,7 +29,7 @@
         <p>Then run the <code class="highlighter-rouge">rollbackOneChangeSetSQL</code> command, with your information:</p>
         <figure class="highlight">
             <pre xml:space="preserve">
-                <code class="language-text" data-lang="text">liquibase --changeLogFile=changelog.xml rollbackOneChangeSetSQL --changeSetAuthor="LiquibaseProUser" --changeSetId="createProc-proschema" --changeSetPath=changelog.xml --force</code>
+                <code class="language-text" data-lang="text">liquibase --changeLogFile=changelog.xml rollbackOneChangeSetSQL --changeSetAuthor="LiquibaseProUser" --changeSetId="createProc-proschema" --changeSetPath=changelog.xml</code>
             </pre>
         </figure>
         <p>For more command specific help, type <code class="highlighter-rouge">liquibase rollbackonechangesetSQL --help</code> into the command prompt.</p>


### PR DESCRIPTION
Removing --force from helper command.  --force is not needed nor is required for the sql helper command