### PR TITLE
command tagExists example corrected with additional --tag command arg…

### DIFF
--- a/Content/commands/community/tagExists.html
+++ b/Content/commands/community/tagExists.html
@@ -3,18 +3,18 @@
     <head><title>tagExists command | Liquibase Docs</title>
         <meta rel="canonical" href="https://docs.liquibase.com/commands/community/tagexists.html" />
         <link href="../../Z_Resources/Stylesheets/TableStyles.css" rel="stylesheet" MadCap:stylesheetType="table" />
-        <meta name="description" content="Reference information and use cases for the tagExists &lt;tag string&gt; command. The tagExists &lt;tag string&gt; command checks whether the tag you specify already exists in your database." />
+        <meta name="description" content="Reference information and use cases for the tagExists --tag &lt;tag string&gt; command. The tagExists --tag &lt;tag string&gt; command checks whether the tag you specify already exists in your database." />
     </head>
     <body>
-        <h1><code>tagExists &lt;tag string&gt;</code> command</h1>
-        <p>The <code>tagExists &lt;tag string&gt;</code> command checks whether the tag you specify already exists in your database.</p>
+        <h1><code>tagExists --tag &lt;tag string&gt;</code> command</h1>
+        <p>The <code>tagExists --tag &lt;tag string&gt;</code> command checks whether the tag you specify already exists in your database.</p>
         <h2>Uses</h2>
-        <p>The <code>tagExists &lt;tag string&gt;</code> command is typically used to identify whether the specified tag exists in the database or specifically in the <MadCap:variable name="General.databasechangelog" /> table. Running the <code>tagExists &lt;tag string&gt;</code> command checks for the tag and, based on whether it exists or not, provides the appropriate output.</p>
-        <h2>Running the <code>tagExists &lt;tag string&gt;</code> command</h2>
-        <p>To run the <code>tagExists &lt;tag string&gt;</code> command, you can specify the driver, classpath, and URL in your <code><MadCap:variable name="General.liquiPropFile"></MadCap:variable></code> file.  For more information, see <a href="https://docs.liquibase.com/workflows/liquibase-community/creating-config-properties.html?Highlight=liquibase.properties"><MadCap:xref href="../../workflows/liquibase-community/creating-config-properties.html">Creating and configuring a [%=General.liquiPropFile%] file</MadCap:xref></a>. You can also specify these properties in your command line.</p>
-        <p>Then run the <code>tagExists &lt;tag string&gt;</code> command:</p><pre><code class="language-text">liquibase --changeLogFile=communityOnly.xml tagExists myTag</code></pre>
+        <p>The <code>tagExists --tag &lt;tag string&gt;</code> command is typically used to identify whether the specified tag exists in the database or specifically in the <MadCap:variable name="General.databasechangelog" /> table. Running the <code>tagExists --tag &lt;tag string&gt;</code> command checks for the tag and, based on whether it exists or not, provides the appropriate output.</p>
+        <h2>Running the <code>tagExists --tag &lt;tag string&gt;</code> command</h2>
+        <p>To run the <code>tagExists --tag &lt;tag string&gt;</code> command, you can specify the driver, classpath, and URL in your <code><MadCap:variable name="General.liquiPropFile"></MadCap:variable></code> file.  For more information, see <a href="https://docs.liquibase.com/workflows/liquibase-community/creating-config-properties.html?Highlight=liquibase.properties"><MadCap:xref href="../../workflows/liquibase-community/creating-config-properties.html">Creating and configuring a [%=General.liquiPropFile%] file</MadCap:xref></a>. You can also specify these properties in your command line.</p>
+        <p>Then run the <code>tagExists --tag &lt;tag string&gt;</code> command:</p><pre><code class="language-text">liquibase --changeLogFile=communityOnly.xml tagExists --tag myTag</code></pre>
         <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">Enter the name of the <MadCap:variable name="General.changelog" style="font-style: italic;" /> and the tag that you want to use in place of <code>communityOnly.xml</code> and <code>myTag</code>.</p>
-        <h2><code>tagExists &lt;tag string&gt;</code> global <MadCap:variable name="General.Param/Attribute" />s</h2>
+        <h2><code>tagExists --tag &lt;tag string&gt;</code> global <MadCap:variable name="General.Param/Attribute" />s</h2>
         <table style="mc-table-style: url('../../Z_Resources/Stylesheets/TableStyles.css');margin-left: auto;margin-right: auto;" class="TableStyle-TableStyles" cellspacing="0">
             <col class="TableStyle-TableStyles-Column-Column1" style="width: 300px;" />
             <col class="TableStyle-TableStyles-Column-Column1" style="width: 300px;" />


### PR DESCRIPTION
…ument.

This fix is needed for 4.4.x as it will break if the --tag command argument is not used