### PR TITLE
Remove references to examples/start-h2 scripts

### DIFF
--- a/Content/Z_Resources/Snippets/install-backup/installer-backup.flsnp
+++ b/Content/Z_Resources/Snippets/install-backup/installer-backup.flsnp
@@ -142,15 +142,15 @@
         <h2 id="starting-the-example-h2-database">Starting the Example H2 Database</h2>
         <p>H2 is a standard SQL database and can be used to simulate anything you are required to do in your own database.</p>
         <ul>
-            <li>To Start the example database, run <code class="highlighter-rouge">examples/start-h2</code>.</li>
+            <li>To Start the example database, run <code class="highlighter-rouge">liquibase init start-h2</code>.</li>
             <li>To Stop the example database, use <code class="highlighter-rouge">ctrl-c</code>.</li>
         </ul>
-        <p>Running <code class="highlighter-rouge">examples/start-h2</code> starts a local H2 database that listends on port 9090 and opens a browser to the database console on the same port.</p>
+        <p>Running <code class="highlighter-rouge">liquibase init start-h2</code> starts a local H2 database that listens on port 9090 and opens a browser to the database console on the same port.</p>
         <blockquote>
             <p><strong>Note:</strong> The Example H2 database does not store data and will reset to its starting state when the start-h2 process ends.</p>
         </blockquote>
         <h3 id="about-the-console">About the Console</h3>
-        <p>The start-h2 script starts two databases:</p>
+        <p>The start-h2 command starts two databases:</p>
         <ul>
             <li><strong>A Developer Database:</strong> Corresponds to what you may use as a local database.</li>
             <li><strong>An Integration Database:</strong> Corresponds to another database in your pipeline.</li>

--- a/Content/install/tutorials/h2.html
+++ b/Content/install/tutorials/h2.html
@@ -24,7 +24,6 @@
         </ul>
         <h2>Driver Information</h2>
         <p>To use <MadCap:variable name="General.Liquibase" /> and H2, you need to have the JDBC driver .jar file. <MadCap:variable name="General.Liquibase" /> includes the H2 in-memory database and the <code>h2-version.jar</code> file in <code>liquibase/lib</code> in the installation package. For more information, see <MadCap:xref href="../../workflows/liquibase-community/adding-and-updating-liquibase-drivers.htm">Adding and Updating [%=General.Liquibase%] Drivers</MadCap:xref>.</p>
-        <p>You can find the H2 database in the  <code>../examples: start-h2.bat</code> folder along with the sample SQL and XML <MadCap:variable name="General.changelog" style="font-style: italic;" /><i>s</i> and the <code><MadCap:variable name="General.liquiPropFile"></MadCap:variable></code> file. You can find the <code>h2-version.jar</code> file  in the <code>liquibase/lib</code> directory.</p>
         <p>If you use Maven,   put the H2 driver in a location that your Maven build can access. Configure the Maven <code>pom.xml</code> file to use the local copy of the driver jar file. For example:</p><pre><code class="language-text">&lt;dependency&gt;
 &lt;groupId&gt;com.h2database&lt;/groupId&gt;
 &lt;artifactId&gt;h2&lt;/artifactId&gt;
@@ -33,10 +32,10 @@
         <h2>Testing Your Connection</h2>
         <p>For <MadCap:variable name="General.Liquibase" /> and H2 to work, you need to:</p>
         <ol>
-            <li>Start the H2 database by navigating to the <code>examples</code> folder in the CLI and running <code>start-h2</code>.</li>
+            <li>Start the H2 database by navigating to the <code>examples</code> folder in the CLI and running <code>liquibase init start-h2</code>.</li>
             <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">To stop the example H2 database, you can use <code>ctrl-c</code>.</p>
-            <p>The <code>start-h2</code> script starts a local H2 database on port 9090 and opens the database console on the same port in the browser. </p>
-            <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">The example H2 database does not store data and will reset to its starting state when the <code>start-h2</code> process ends.</p>
+            <p>The <code>init start-h2</code> command starts a local H2 database on port 9090 and opens the database console on the same port in the browser. </p>
+            <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">The example H2 database does not store data and will reset to its starting state when the <code>init start-h2</code> process ends.</p>
             <ul>
                 <li>A developer database corresponds to what you may use as a local database.</li>
                 <li>An integration database corresponds to another database in your pipeline.</li>

--- a/Content/install/tutorials/hibernate.htm
+++ b/Content/install/tutorials/hibernate.htm
@@ -37,7 +37,7 @@
         <h2>Supported Commands and Change Types</h2>
         <p>For information on supported <MadCap:xref href="../../commands/home.htm">Liquibase Commands</MadCap:xref> and <MadCap:xref href="../../change-types/home.html">[%=General.changetypes%]</MadCap:xref>, go to <MadCap:xref href="home.html">[%=General.Liquibase%] Database Tutorials</MadCap:xref> and select the type of database you are using Hibernate with.</p>
         <h2>Testing Your Connection</h2>
-        <p>To start the H2 server included in the <MadCap:variable name="General.Liquibase" /> distribution, open the command line, go to <code>$LIQUIBASE_HOME/examples</code>, and run <code>start-h2</code>. This will open a database console in your browser.</p>
+        <p>To start the H2 server included in the <MadCap:variable name="General.Liquibase" /> distribution, open the command line, go to <code>$LIQUIBASE_HOME/examples</code>, and run <code>liquibase init start-h2</code>. This will open a database console in your browser.</p>
         <p>You can check the status of the database by entering <code>create table test_table (id int)</code> in the text area of the database console and selecting <b>Run</b>. You will see <code>TEST_TABLE</code> appear in the object view. For more information, see <MadCap:xref href="h2.html">Using [%=General.Liquibase%] with H2</MadCap:xref>.</p>
         <h2>Creating a New Liquibase Project with Hibernate</h2>
         <p>We will be creating a Maven project for this tutorial. To configure a <MadCap:variable name="General.Liquibase" /> project for Hibernate, perform the following steps:</p>


### PR DESCRIPTION
## Description

With 4.8 we added a new `liquibase init start-h2` command. The old examples/start-h2 scripts are still there for anyone still looking for them, but it's better to always be documenting `liquibase init start-h2` because it's going to more consistently work (like it works easier if using docker) and there is no need to make people wonder what the differences are between the scripts. 

The examples/start-h2 script just calls liquibase init start-h2 in 4.9+. At some point we'd like to remove the examples/start-h2 scripts but we'll wait for usage to die down.