### PR TITLE
Removed docs from very old liquibase version

### DIFF
--- a/Content/tools-integrations/community-supported/servlet-listener.html
+++ b/Content/tools-integrations/community-supported/servlet-listener.html
@@ -36,86 +36,44 @@
     &lt;listener-class&gt;liquibase.integration.servlet.LiquibaseServletListener&lt;/listener-class&gt;  
 &lt;/listener&gt;</code>
             </pre>
-        <p><strong>If using <MadCap:variable name="General.Liquibase" /> 1.9.x</strong>
-        </p><pre xml:space="preserve"><code class="language-xml" data-lang="xml">&lt;context-param&gt;  
-    &lt;param-name&gt;LIQUIBASE_CHANGELOG&lt;/param-name&gt;  
-    &lt;param-value&gt;com/example/db.changelog.xml&lt;/param-value&gt;  
-&lt;/context-param&gt;  
 
-&lt;context-param&gt;  
-    &lt;param-name&gt;LIQUIBASE_DATA_SOURCE&lt;/param-name&gt;  
-    &lt;param-value&gt;java:comp/env/jdbc/default&lt;/param-value&gt;  
-&lt;/context-param&gt;  
-
-&lt;context-param&gt;  
-    &lt;param-name&gt;LIQUIBASE_HOST_EXCLUDES&lt;/param-name&gt;  
-    &lt;param-value&gt;production1.example.com, production2.example.com&lt;/param-value&gt;  
-&lt;/context-param&gt;  
-
-&lt;context-param&gt;  
-    &lt;param-name&gt;LIQUIBASE_FAIL_ON_ERROR&lt;/param-name&gt;  
-    &lt;param-value&gt;true&lt;/param-value&gt;  
-&lt;/context-param&gt;  
-
-&lt;context-param&gt;  
-    &lt;param-name&gt;LIQUIBASE_CONTEXTS&lt;/param-name&gt;  
-    &lt;param-value&gt;production&lt;/param-value&gt;  
-&lt;/context-param&gt;  
-
-&lt;listener&gt;  
-    &lt;listener-class&gt;liquibase.servlet.LiquibaseServletListener&lt;/listener-class&gt;  
-&lt;/listener&gt;</code>
-            </pre>
         <h2 id="available-context-parameters">Available context-parameters:</h2>
         <table>
             <tr>
                 <td>Parameter</td>
-                <td>1.9 version</td>
                 <td>Description</td>
             </tr>
             <tr>
                 <td><code>liquibase.changelog</code>
-                </td>
-                <td><code>LIQUIBASE_CHANGELOG</code>
                 </td>
                 <td>Specifies the <MadCap:variable name="General.changelog" style="font-style: italic;" /> file to run <b>required</b></td>
             </tr>
             <tr>
                 <td><code>liquibase.datasource</code>
                 </td>
-                <td><code>LIQUIBASE_DATA_SOURCE</code>
-                </td>
                 <td>JNDI datasource to use for running <MadCap:variable name="General.Liquibase" />. Note that the <code>LIQUIBASE_DATA_SOURCE</code> can be different than the data source the rest of your web app uses if that data source does not have sufficient privileges to create or alter tables etc. <b>required</b></td>
             </tr>
             <tr>
                 <td><code>liquibase.host.excludes</code>
-                </td>
-                <td><code>LIQUIBASE_HOST_EXCLUDES</code>
                 </td>
                 <td>Specify host names on which you do NOT want <MadCap:variable name="General.Liquibase" /> to run. Specifying this parameter allows you to deploy the same WAR/EAR to multiple machines in different environments and not have <MadCap:variable name="General.Liquibase" /> run on all of them.</td>
             </tr>
             <tr>
                 <td><code>liquibase.host.includes</code>
                 </td>
-                <td><code>LIQUIBASE_HOST_INCLUDES</code>
-                </td>
                 <td>Specify the ONLY host names on which want <MadCap:variable name="General.Liquibase" /> to run. Specifying this parameter allows you to deploy the same WAR/EAR to multiple machines in different environments and not have <MadCap:variable name="General.Liquibase" /> run on all of them.</td>
             </tr>
             <tr>
                 <td><code>liquibase.onerror.fail</code>
-                </td>
-                <td><code>LIQUIBASE_FAIL_ON_ERROR</code>
                 </td>
                 <td>Specify if an exception is thrown by <MadCap:variable name="General.Liquibase" /> if an error occurs. Setting the value to "true" (default) will cause the exception to be thrown and keep the site from initializing properly. Setting the value to "false" will allow the site to deploy as normal, but the database will be in an undefined state.</td>
             </tr>
             <tr>
                 <td><code>liquibase.contexts</code>
                 </td>
-                <td><code>LIQUIBASE_CONTEXTS</code>
-                </td>
                 <td>A comma separated lists of the <MadCap:xref href="../../concepts/changelogs/attributes/contexts.html">Contexts</MadCap:xref> to run in.</td>
             </tr>
         </table>
-        <p>If you want to control servers that run <MadCap:variable name="General.Liquibase" /> but don't want to set the <code>LIQUIBASE_HOST_EXCLUDES/LIQUIBASE_HOST_INCLUDES</code> attributes, you can specify the <code>liquibase.should.run=[true/false]</code> system property.</p>
+        <p>If you want to control servers that run <MadCap:variable name="General.Liquibase" /> but don't want to set the <code>liquibase.host.includes/liquibase.host.excludes</code> attributes, you can specify the <code>liquibase.should.run=[true/false]</code> system property.</p>
     </body>
 </html>


### PR DESCRIPTION
## Description

In adding to the servlet docs, I noticed that half the the page is documenting setup from Liquibase 1.9 and before.

2.0 was released 12 years ago, so maybe OK to stop documenting the old setup? If we'd prefer to keep it in feel free to just close this PR