### PR TITLE
Fixed incorrect "4.9.0.xsd" references

### DIFF
--- a/Content/Z_Resources/Snippets/code/liquibase-xsd-xml-changelog-closed.flsnp
+++ b/Content/Z_Resources/Snippets/code/liquibase-xsd-xml-changelog-closed.flsnp
@@ -8,8 +8,8 @@
 	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
 	xmlns:pro="http://www.liquibase.org/xml/ns/pro"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.0.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
 		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
-		http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.9.0.xsd"&gt;</code>
+		http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.9.xsd"&gt;</code>
     </body>
 </html>

--- a/Content/Z_Resources/Snippets/code/liquibase-xsd-xml-changelog-open.flsnp
+++ b/Content/Z_Resources/Snippets/code/liquibase-xsd-xml-changelog-open.flsnp
@@ -8,8 +8,8 @@
 	xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
 	xmlns:pro="http://www.liquibase.org/xml/ns/pro"
 	xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.0.xsd
+		http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.9.xsd
 		http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd
-		http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.9.0.xsd"</code>
+		http://www.liquibase.org/xml/ns/pro http://www.liquibase.org/xml/ns/pro/liquibase-pro-4.9.xsd"</code>
     </body>
 </html>


### PR DESCRIPTION
## Description

Fixes liquibase/liquibase#2707 . XSD files never have the ".0" part of the version in them