### PR TITLE
Added a note on property escaping

### DIFF
--- a/Content/concepts/changelogs/property-substitution.html
+++ b/Content/concepts/changelogs/property-substitution.html
@@ -35,6 +35,9 @@
         </ol>
         <p>Once a property has been set, it cannot be changed. Also, only the first definition is used, others are skipped.</p>
         <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">If the content of <code>${property-name}</code> does not match a property, it is left as-is and it is not removed.  The supported format includes alphanumeric characters, <code>+</code>, <code>-</code>, <code>.</code> , and <code>_</code>.</p>
+
+        <p class="note" MadCap:autonum="&lt;b&gt;Note: &lt;/b&gt;">If you do not want to replace an otherwise-matching <code>${property-name}</code> expression, add <code>:</code> to the beginning of the expression. An expression of <code>${: property-name}</code> will always be converted to <code>${property-name}</code> regardless of whether <code>property-name</code> is defined or not.</p>
+
         <h2>Nested properties</h2>
         <table style="width: 100%;margin-left: auto;margin-right: auto;mc-table-style: url('../../Z_Resources/Stylesheets/TableStyles.css');" class="TableStyle-TableStyles" cellspacing="0">
             <col class="TableStyle-TableStyles-Column-Column1" />


### PR DESCRIPTION
## Description

Added docs on using `${: property-name}` escape syntax.

This syntax is valid in the current liquibase version. Not sure how far back it goes, but a while. 