### PR TITLE
Fixed example changeset

### DIFF
--- a/Content/workflows/liquibase-community/liquibase-auto-rollback.htm
+++ b/Content/workflows/liquibase-community/liquibase-auto-rollback.htm
@@ -16,8 +16,9 @@ create table example1 ( id int primary key, name varchar(255) );
 				
 -- changeset liquibaseuser:2
 insert into example1 values ('1','The First', 'Country')
-insert into example1 values ('1','The Second', 'Country2')
--- rollback delete from example1 where id='1'</code></pre>
+insert into example1 values ('2','The Second', 'Country2')
+-- rollback delete from example1 where id='1'
+-- rollback delete from example1 where id='2'</code></pre>
         <h2>Using the <code>&lt;rollback&gt;</code> tag</h2>
         <p>The <code>&lt;rollback&gt;</code> tag describes how to roll back a change using SQL statements, <MadCap:variable name="General.changetypes" />s, or a reference to a previous <MadCap:variable name="General.changeset" />.</p>
         <p>You can have plain SQL in the content part of the <code>&lt;rollback&gt;</code> element. <MadCap:variable name="General.Liquibase" /> treats the text in the element as the <code>&lt;sql&gt;</code> <MadCap:variable name="General.changetypes" /> with <code>stripComments</code> set to <code>true</code>, <code>splitStatements</code> set to <code>true</code>, and <code>endDelimiter</code> set to <code>;</code>. For more details, see the XML example from the <MadCap:xref href="../../change-types/sql.html">sql</MadCap:xref> documentation.</p><pre><code class="language-xml">&lt;changeSet id="1" author="bob"&gt;


### PR DESCRIPTION
Fixed the example since the id is a primary key the example changeset would not work on the database.