### PR TITLE
errorIfMissingOrEmpty default is true

### DIFF
--- a/Content/concepts/changelogs/attributes/includeall.html
+++ b/Content/concepts/changelogs/attributes/includeall.html
@@ -90,7 +90,7 @@
                 <tr>
                     <td><code>errorIfMissingOrEmpty</code>
                     </td>
-                    <td>Controls what happens if the path listed does not exist or is an empty directory. <b>Default: false</b>. If set to true, the update will fail.</td>
+                    <td>Controls what happens if the path listed does not exist or is an empty directory. <b>Default: true</b>. If set to true, the update will fail.</td>
                     <td>&#160;</td>
                 </tr>
                 <tr>


### PR DESCRIPTION
errorIfMissingOrEmpty has been true by default for a couple of version, looks like the docs didnt get updated.